### PR TITLE
Sanitize hidden input on blur event

### DIFF
--- a/vendor/assets/javascripts/autonumeric_ujs.js
+++ b/vendor/assets/javascripts/autonumeric_ujs.js
@@ -48,7 +48,7 @@ window.AutonumericRails = AutonumericRails = (function() {
         this.create_hidden_field();
         this.init_autonumeric();
         this.sanitize_value();
-        this.field.on('keyup', $.proxy(function() {
+        this.field.on('keyup blur', $.proxy(function() {
             this.sanitize_value();
         }, this));
     }


### PR DESCRIPTION
When the user fills the input using the autocomplete, the keyup event never triggers
